### PR TITLE
Fix dead links to paper

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ reflection
 
 [![Build Status](https://secure.travis-ci.org/ekmett/reflection.png?branch=master)](http://travis-ci.org/ekmett/reflection)
 
-This package provides an implementation of the ideas presented in [Functional Pearl: Implicit Configurations](http://www.cs.rutgers.edu/~ccshan/prepose/prepose.pdf) by Oleg Kiselyov and Chung-Chieh Shan. However, the API has been implemented in a much more efficient manner.
+This package provides an implementation of the ideas presented in [Functional Pearl: Implicit Configurations](http://okmij.org/ftp/Haskell/tr-15-04.pdf) by Oleg Kiselyov and Chung-Chieh Shan. However, the API has been implemented in a much more efficient manner.
 
 Contact Information
 -------------------

--- a/fast/Data/Reflection.hs
+++ b/fast/Data/Reflection.hs
@@ -34,7 +34,7 @@
 -- Pearl: Implicit Configurations paper by Oleg Kiselyov and
 -- Chung-chieh Shan.
 --
--- <http://www.cs.rutgers.edu/~ccshan/prepose/prepose.pdf>
+-- <http://okmij.org/ftp/Haskell/tr-15-04.pdf>
 --
 -- The approach from the paper was modified to work with Data.Proxy
 -- and to cheat by using knowledge of GHC's internal representations

--- a/reflection.cabal
+++ b/reflection.cabal
@@ -62,7 +62,7 @@ description:
   .
   That package is an implementation of the ideas presented in the
   paper \"Functional Pearl: Implicit Configurations\" by Oleg Kiselyov
-  and Chung-chieh Shan (<http://www.cs.rutgers.edu/~ccshan/prepose/prepose.pdf original paper>). However, the API has been streamlined to improve
+  and Chung-chieh Shan (<http://okmij.org/ftp/Haskell/tr-15-04.pdf original paper>). However, the API has been streamlined to improve
   performance.
   .
   Austin Seipp's tutorial <https://www.fpcomplete.com/user/thoughtpolice/using-reflection Reflecting values to types and back> provides a summary of the

--- a/slow/Data/Reflection.hs
+++ b/slow/Data/Reflection.hs
@@ -23,7 +23,7 @@
 -- Pearl: Implicit Configurations paper by Oleg Kiselyov and
 -- Chung-chieh Shan.
 --
--- <http://www.cs.rutgers.edu/~ccshan/prepose/prepose.pdf>
+-- <http://okmij.org/ftp/Haskell/tr-15-04.pdf>
 --
 -- The approach from the paper was modified to work with Data.Proxy
 -- and streamline the API by Edward Kmett and Elliott Hird.


### PR DESCRIPTION
The old link 404s now.