### PR TITLE
fix build error in examples/Constraints.hs

### DIFF
--- a/examples/Constraints.hs
+++ b/examples/Constraints.hs
@@ -22,7 +22,7 @@ instance Newtype (Lift p a s) a where
 with :: Def p a -> (forall s. Reifies s (Def p a) => Lift p a s) -> a
 with d v = reify d $ lower . asProxyOf v
 
-reifyInstance :: Def p a -> (forall s. Reifies s (Def p a) => Proxy s -> r) -> r
+reifyInstance :: Def p a -> (forall (s :: *). Reifies s (Def p a) => Proxy s -> r) -> r
 reifyInstance = reify
 
 asProxyOf :: f s -> Proxy s -> f s


### PR DESCRIPTION
```
stack --resolver nightly-2016-10-04 exec ghci examples/Constraints.hs                                                                                                   ✘
Run from outside a project, using implicit global project config
Using resolver: nightly-2016-10-04 specified on command line

examples/Constraints.hs:26:17: error:
    • Couldn't match type ‘k’ with ‘*’
      ‘k’ is a rigid type variable bound by
        the type signature for:
          reifyInstance :: forall k (p :: * -> Constraint) a r.
                           Def p a
                           -> (forall (s :: k). Reifies s (Def p a) => Proxy s -> r) -> r
        at examples/Constraints.hs:25:18
      Expected type: Proxy s -> r
        Actual type: Proxy s -> r
    • In the expression: reify
      In an equation for ‘reifyInstance’: reifyInstance = reify
    • Relevant bindings include
        reifyInstance :: Def p a
                         -> (forall (s :: k). Reifies s (Def p a) => Proxy s -> r) -> r
          (bound at examples/Constraints.hs:26:1)
```