### PR TITLE
Adapt to the Semigroup–Monoid Proposal

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,6 @@
+# next
+* Add `Semigroup` instance for `ReflectedMonoid`.
+
 # 2.1.2
 * Support cross-compilation and unregistered GHC builds.
 

--- a/examples/Monoid.hs
+++ b/examples/Monoid.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE Rank2Types, FlexibleContexts, UndecidableInstances #-}
+{-# LANGUAGE CPP, Rank2Types, FlexibleContexts, UndecidableInstances #-}
 import Data.Reflection -- from reflection
-import Data.Monoid     -- from base
+import Data.Semigroup  -- from base
 import Data.Proxy      -- from tagged
 
 -- | Values in our dynamically-constructed 'Monoid' over 'a'
@@ -9,8 +9,13 @@ newtype M a s = M { runM :: a } deriving (Eq,Ord)
 -- | A dictionary describing a 'Monoid'
 data Monoid_ a = Monoid_ { mappend_ :: a -> a -> a, mempty_ :: a }
 
+instance Reifies s (Monoid_ a) => Semigroup (M a s) where
+  a <> b = M $ mappend_ (reflect a) (runM a) (runM b)
+
 instance Reifies s (Monoid_ a) => Monoid (M a s) where
-  mappend a b        = M $ mappend_ (reflect a) (runM a) (runM b)
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#endif
   mempty = a where a = M $ mempty_ (reflect a)
 
 -- Construct a 'Monoid' instance out of a binary operation and unit that you have in scope!

--- a/fast/Data/Reflection.hs
+++ b/fast/Data/Reflection.hs
@@ -117,7 +117,6 @@ import Data.Bits
 
 #if __GLASGOW_HASKELL__ < 710
 import Data.Foldable
-import Data.Monoid
 #endif
 
 import Data.Semigroup as Sem

--- a/reflection.cabal
+++ b/reflection.cabal
@@ -70,6 +70,10 @@ library
     build-depends:
       tagged >= 0.4.4 && < 1
 
+  if !impl(ghc >= 8.0)
+    build-depends:
+      semigroups >= 0.11 && < 0.19
+
   default-language: Haskell98
 
   if flag(template-haskell) && impl(ghc)


### PR DESCRIPTION
In the next version of `base` (4.11), `Semigroup` will be a superclass of `Monoid`. This PR updates `reflection` accordingly.