### PR TITLE
Support semigroups-0.19

### DIFF
--- a/reflection.cabal
+++ b/reflection.cabal
@@ -82,7 +82,7 @@ library
 
   if !impl(ghc >= 8.0)
     build-depends:
-      semigroups >= 0.11 && < 0.19
+      semigroups >= 0.11 && < 0.20
 
   default-language: Haskell98
 


### PR DESCRIPTION
Pardon an automatically-posted pull request; this is a part of [Operation Vanguard](https://github.com/haskell-vanguard/haskell-vanguard). Note that this does not guarantee that tests and benchmarks are buildable.