### PR TITLE
Add NOINLINE pragma to reifyTypeable

### DIFF
--- a/fast/Data/Reflection.hs
+++ b/fast/Data/Reflection.hs
@@ -570,6 +570,7 @@ reifyTypeable a k = unsafePerformIO $ do
                 reifyByte (fromIntegral (n `shiftR` 56)) (\s7 ->
                   reflectBefore (fmap return k) $
                     stable s0 s1 s2 s3 s4 s5 s6 s7))))))))
+{-# NOINLINE reifyTypeable #-}
 
 
 data ReifiedMonoid a = ReifiedMonoid { reifiedMappend :: a -> a -> a, reifiedMempty :: a }


### PR DESCRIPTION
This might not fix any real issues, I don't actually grok how this magic works.  However based on the other uses of NOINLINE in this module it seems consistent to add one to reifyTypeable as well.