### PR TITLE
Mark give, reify et al. as NOINLINE on GHC 8.10 or older

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+# next [????.??.??]
+* Fix a bug in which `give` (and possibly `reify`, `reifyNat`, and
+  `reifySymbol`) could be unsoundly inlined by GHC 8.10 or older to produce
+  incorrect runtime results.
+
 # 2.1.5 [2019.08.27]
 * Fix a bug in which `reifyNat` would yield incorrect results for very large
   `Integer`s on GHC 8.2 or later.

--- a/reflection.cabal
+++ b/reflection.cabal
@@ -113,11 +113,13 @@ test-suite spec
   hs-source-dirs: tests
   main-is: Spec.hs
   other-modules: ReifyNatSpec
+                 T47Spec
   ghc-options: -Wall
   default-language: Haskell98
   build-tool-depends: hspec-discover:hspec-discover >= 1.8
   build-depends:
-    base       >= 2 && < 5,
-    hspec      >= 2 && < 3,
-    QuickCheck >= 2 && < 3,
+    base       >= 2   && < 5,
+    containers >= 0.1 && < 0.7,
+    hspec      >= 2   && < 3,
+    QuickCheck >= 2   && < 3,
     reflection

--- a/tests/T47Spec.hs
+++ b/tests/T47Spec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- | A regression test for issue #47.
+module T47Spec where
+
+import qualified Data.Map as M
+import Data.Map (Map)
+import Data.Reflection
+import Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec =
+  describe "Given" $ do
+    it "should give Normal properly" $
+      give Normal (toJSON (Foo Bar)) `shouldBe`
+      Object (M.fromList [("Foo",String "Bar")])
+    it "should give ViaShow properly" $
+      give ViaShow (toJSON (Foo Bar)) `shouldBe`
+      Object (M.fromList [("Foo",String "SHOWBAR")])
+
+----------------------------------------------------------------------------
+-- Types
+----------------------------------------------------------------------------
+
+data Foo = Foo Bar
+
+instance Show Foo where
+  show _ = "SHOWFOO"
+
+data Bar = Bar | BarBar
+
+instance Show Bar where
+  show _ = "SHOWBAR"
+
+----------------------------------------------------------------------------
+-- ToJSON instances
+----------------------------------------------------------------------------
+
+instance Given Style => ToJSON Foo where
+  toJSON (Foo x) = Object $ M.singleton "Foo" (toJSON x)
+
+instance Given Style => ToJSON Bar where
+  toJSON x = case given of
+    Normal -> String $ case x of
+                Bar    -> "Bar"
+                BarBar -> "BarBar"
+    ViaShow -> String $ show x
+
+data Style = Normal | ViaShow
+
+----------------------------------------------------------------------------
+-- Minimized aeson
+----------------------------------------------------------------------------
+
+class ToJSON a where
+  toJSON :: a -> Value
+
+data Value
+  = Object !(Map String Value)
+  | String !String
+  deriving (Eq, Show)


### PR DESCRIPTION
This is needed to avoid [GHC#16893](https://gitlab.haskell.org/ghc/ghc/issues/16893), a nasty bug affecting GHC 8.10 and older in which `unsafeCoerce` can be inlined too much, producing incorrect runtime results. #47 demonstrates a concrete example of `give` (which is defined in terms of `unsafeCoerce`) actually going wrong at runtime, and since `reify`/`reifyNat`/`reifySymbol` are also defined directly in terms of `unsafeCoerce`, they also run the same risk.

This works around the problem by marking `give`, `reify`, etc. as `NOINLINE` on GHC 8.10 or older to prevent GHC#16893 from happening. The code from #47 has been converted to a regression test to avoid this sort of thing from regressing in the future.

Fixes #47.