### PR TITLE
Add link to Arnaud Spiwack's tutorial

### DIFF
--- a/reflection.cabal
+++ b/reflection.cabal
@@ -25,8 +25,12 @@ description:
   and Chung-chieh Shan (<http://okmij.org/ftp/Haskell/tr-15-04.pdf original paper>).
   However, the API has been streamlined to improve performance.
   .
-  Austin Seipp's tutorial <https://www.schoolofhaskell.com/user/thoughtpolice/using-reflection Reflecting values to types and back> provides a summary of the
+  There are a handful of tutorials on how to use this library:
+  .
+  * Austin Seipp's tutorial <https://www.schoolofhaskell.com/user/thoughtpolice/using-reflection Reflecting values to types and back> provides a summary of the
   approach taken by this library, along with more motivating examples.
+  .
+  * Arnaud Spiwack's tutorial <https://www.tweag.io/posts/2017-12-21-reflection-tutorial.html All about reflection> explains how to use this library.
 tested-with:   GHC == 7.0.4
              , GHC == 7.2.2
              , GHC == 7.4.2


### PR DESCRIPTION
I've been told that my tutorial has been helpful. At least to some. Maybe it will be helpful to more people if the package links to it. So this is me, humbly proposing that this tutorial be linked from the package description.

There is not really many reflection tutorial, and it's still a bit of an obscure corner of Haskell. Which I think ought to be better known. My though is that having more tutorials readily accessible from the package would probably help.