### PR TITLE
Fix a memory leak in reifyTypeable (fixes #54)

### DIFF
--- a/examples/reflection-examples.cabal
+++ b/examples/reflection-examples.cabal
@@ -56,7 +56,7 @@ executable reflection-from-json
                        aeson >= 1 && < 2.3,
                        base >= 4.9 && < 5,
                        microlens,
-                       microlens-aeson,
+                       microlens-aeson >= 2.5.1,
                        reflection,
                        semigroups,
                        tagged,

--- a/fast/Data/Reflection.hs
+++ b/fast/Data/Reflection.hs
@@ -592,14 +592,14 @@ instance Reifies (StableBox w0 w1 a) (Box b) => Reifies (Stable w0 w1 a) b where
   reflect p = case reflect (stableBox p) of
     Box a -> a
 
--- Ensure that exactly one dictionary of Reifies (StableBox ...) is created and evaluated per a reifyTypeable call.
+-- Ensure that exactly one dictionary of Reifies (StableBox ...) is created and evaluated per reifyTypeable call.
 --
 -- Evaluating the dictionary's thunk frees the allocated StablePtr, and the contents of the StablePtr replace the thunk.
 -- Creating two dictionaries would mean a double free upon their evaluation, and leaving a dictionary unevaluated would
--- leak the StablePtr (see https://github.com/ekmett/reflection/issues/54 ).
+-- leak the StablePtr (see https://github.com/ekmett/reflection/issues/54).
 --
 -- To separate evaluation of the dictionary and evaluation of the actual argument passed to reifyTypeable, we insert a
--- Box inbetween.
+-- Box in between.
 withStableBox :: Reifies (StableBox w0 w1 a) (Box a) => (Reifies (Stable w0 w1 a) a => Proxy (Stable w0 w1 a) -> r) -> Proxy (Stable w0 w1 a) -> IO r
 withStableBox k p = do
   _ <- evaluate $ reflect (stableBox p)

--- a/slow/Data/Reflection.hs
+++ b/slow/Data/Reflection.hs
@@ -193,16 +193,16 @@ instance Reifies (StableBox b0 b1 b2 b3 b4 b5 b6 b7 a) (Box b)
     Box a -> a
 
 -- Ensure that exactly one dictionary of Reifies (StableBox ...) is created and
--- evaluated per a reifyTypeable call.
+-- evaluated per reifyTypeable call.
 --
 -- Evaluating the dictionary's thunk frees the allocated StablePtr, and the
 -- contents of the StablePtr replace the thunk. Creating two dictionaries would
 -- mean a double free upon their evaluation, and leaving a dictionary
 -- unevaluated would leak the StablePtr
--- (see https://github.com/ekmett/reflection/issues/54 ).
+-- (see https://github.com/ekmett/reflection/issues/54).
 --
 -- To separate evaluation of the dictionary and evaluation of the actual
--- argument passed to reifyTypeable, we insert a Box inbetween.
+-- argument passed to reifyTypeable, we insert a Box in between.
 withStableBox
   :: Reifies (StableBox b0 b1 b2 b3 b4 b5 b6 b7 a) (Box a)
   => (Reifies (Stable b0 b1 b2 b3 b4 b5 b6 b7 a) a


### PR DESCRIPTION
Admittedly I am not 100% sure what the point of `reflectBefore` was (does anyone else?)

I strongly suspect it was trying to reinvent `evaluate` out of `return` and `$!`, which I've now replaced with an actual `evaluate $ k p` call.