### PR TITLE
Fix broken Haddock links

### DIFF
--- a/examples/Constraints.hs
+++ b/examples/Constraints.hs
@@ -10,7 +10,7 @@ import Data.Reflection          -- from reflection
 import Data.Semigroup           -- from semigroups
 #endif
 
--- | Values in our dynamically constructed monoid over 'a'
+-- | Values in our dynamically constructed monoid over @a@
 newtype Lift (p :: * -> Constraint) (a :: *) (s :: *) = Lift { lower :: a }
 
 class ReifiableConstraint p where

--- a/examples/Monoid.hs
+++ b/examples/Monoid.hs
@@ -7,7 +7,7 @@ import Data.Reflection -- from reflection
 import Data.Semigroup  -- from base
 #endif
 
--- | Values in our dynamically-constructed 'Monoid' over 'a'
+-- | Values in our dynamically-constructed 'Monoid' over @a@
 newtype M a s = M { runM :: a } deriving (Eq,Ord)
 
 -- | A dictionary describing a 'Monoid'

--- a/fast/Data/Reflection.hs
+++ b/fast/Data/Reflection.hs
@@ -650,7 +650,7 @@ reifyMonoid :: (a -> a -> a) -> a -> (forall (s :: *). Reifies s (ReifiedMonoid 
 reifyMonoid f z m xs = reify (ReifiedMonoid f z) (unreflectedMonoid (m xs))
 
 -- | Fold a value using its 'Foldable' instance using
--- explicitly provided 'Monoid' operations. This is like 'fold'
+-- explicitly provided 'Monoid' operations. This is like 'Data.Foldable.fold'
 -- where the 'Monoid' instance can be manually specified.
 --
 -- @


### PR DESCRIPTION
Fix all broken Haddock links. Now Haddock doesn't emit any warnings about out-of-scope identifiers.